### PR TITLE
Bump-up heroku python runtime to 3.9.7

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.9.0
+python-3.9.7


### PR DESCRIPTION
Bump-up heroku python runtime to 3.9.7